### PR TITLE
Fix nil-pointer panic in offline mode

### DIFF
--- a/mac2mqtt.go
+++ b/mac2mqtt.go
@@ -2230,11 +2230,11 @@ func (app *Application) Run() error {
 	defer networkCheckTicker.Stop()
 
 	// Track connection state
-	lastConnectionState := app.client.IsConnected()
+	lastConnectionState := app.isClientConnected()
 	networkReachable := true
 
 	// Initial setup - only if MQTT is connected
-	if app.client != nil && app.client.IsConnected() {
+	if app.isClientConnected() {
 		app.setDevice(app.client)
 		app.updateVolume(app.client)
 		app.updateMute(app.client)
@@ -2263,7 +2263,7 @@ func (app *Application) Run() error {
 		select {
 		case <-volumeTicker.C:
 			// Check if client is connected before publishing
-			if app.client.IsConnected() {
+			if app.isClientConnected() {
 				app.updateVolume(app.client)
 				app.updateMute(app.client)
 				app.updateMediaDevices(app.client)
@@ -2273,7 +2273,7 @@ func (app *Application) Run() error {
 			}
 
 		case <-batteryTicker.C:
-			if app.client.IsConnected() {
+			if app.isClientConnected() {
 				app.updateBattery(app.client)
 				app.updateDiskUsage(app.client)
 				app.updateCPUUsage(app.client)
@@ -2285,7 +2285,7 @@ func (app *Application) Run() error {
 			}
 
 		case <-awakeTicker.C:
-			if app.client.IsConnected() {
+			if app.isClientConnected() {
 				app.updateCaffeinateStatus(app.client)
 				app.updateDisplayBrightness(app.client)
 			} else if networkReachable {
@@ -2296,7 +2296,7 @@ func (app *Application) Run() error {
 		case <-networkCheckTicker.C:
 			// Periodic network reachability check
 			currentNetworkState := app.isNetworkReachable()
-			currentConnectionState := app.client.IsConnected()
+			currentConnectionState := app.isClientConnected()
 
 			// Log network state changes
 			if currentNetworkState != networkReachable {
@@ -2325,6 +2325,9 @@ func (app *Application) Run() error {
 					log.Println("Attempting to reconnect to MQTT broker...")
 					// The auto-reconnect should handle this, but we can force a reconnection attempt
 					go func() {
+						if app.client == nil {
+							return
+						}
 						if token := app.client.Connect(); token.Wait() && token.Error() != nil {
 							log.Printf("Reconnection attempt failed: %v", token.Error())
 						}
@@ -2333,6 +2336,14 @@ func (app *Application) Run() error {
 			}
 		}
 	}
+}
+
+// isClientConnected reports whether the MQTT client exists and is connected.
+// During offline mode (broker unreachable at startup) app.client is nil, so
+// callers must use this instead of dereferencing app.client directly to avoid
+// a nil-pointer panic.
+func (app *Application) isClientConnected() bool {
+	return app.client != nil && app.client.IsConnected()
 }
 
 // Input validation functions


### PR DESCRIPTION
## Problem

When the MQTT broker is unreachable at the moment `mac2mqtt` starts, `Run()` logs `"starting in offline mode"` and continues with `app.client` left `nil`. It then immediately dereferences it:

```go
// Track connection state
lastConnectionState := app.client.IsConnected()   // panic: nil pointer
```

resulting in:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV ...]
main.(*Application).Run(...)
	mac2mqtt.go:2233
```

This is easy to hit in practice: a macOS LaunchAgent/LaunchDaemon usually starts at login/boot **before** the network (Wi-Fi/VPN/DNS) is ready, which is exactly the case offline mode is meant to handle. With `KeepAlive` the process just crash-loops.

Guarding only that first line isn't enough — the `volume`/`battery`/`awake` tickers and the `networkCheckTicker` branch all call `app.client.IsConnected()` (and `app.client.Connect()`) unguarded too, so the crash simply moves to the first tick (within 30–60s) while still offline.

## Fix

- Add a small nil-safe helper:
  ```go
  func (app *Application) isClientConnected() bool {
      return app.client != nil && app.client.IsConnected()
  }
  ```
- Use it at every connection check in `Run()`.
- Guard the forced-reconnect goroutine against a `nil` client.

No behaviour change when connected; offline mode now stays alive and reconnects via the existing tickers once the broker becomes reachable.

## Testing

- `gofmt`, `go vet`, and `go build` all clean.
- Verified on macOS 26.5 (Apple Silicon): with the broker blocked at startup the agent previously crash-looped; with this change it stays running in offline mode and connects automatically once the broker is reachable.

## Note (not addressed here, to keep this PR focused)

The reconnect branch guarded by `if currentNetworkState && !networkReachable` (around line 2322) looks unreachable: `networkReachable` is assigned `currentNetworkState` a few lines above, so the condition is effectively always false. paho's own auto-reconnect appears to cover reconnection regardless. Happy to open a separate PR if you'd like that tidied up.